### PR TITLE
More accuracy improvements, code to touch the array for more realistic cache usage

### DIFF
--- a/benchmark/linux/instrumented_benchmark.cpp
+++ b/benchmark/linux/instrumented_benchmark.cpp
@@ -267,6 +267,7 @@ bool benchmarkMany(C & vdata, BenchmarkState *overhead, uint32_t n, uint32_t m,
 
   return isok;
 }
+
 template <class C>
 void  benchmarkCopy(C & vdata, BenchmarkState *overhead, uint32_t n, uint32_t m,
                     uint32_t iterations, bool verbose) {
@@ -403,12 +404,11 @@ int main(int argc, char **argv) {
 #else
   std::vector<std::vector<uint16_t> > vdata(m, std::vector<uint16_t>(n));
 #endif
-  std::random_device rd;
-  std::mt19937 gen(rd());
-  std::uniform_int_distribution<> dis(0, 0xFFFF);
+
+  std::mt19937 gen; // use default seed for repeatability
   for (size_t k = 0; k < vdata.size(); k++) {
       for (size_t k2 = 0; k2 < vdata[k].size(); k2++) {
-        vdata[k][k2] = dis(gen); // random init.
+        vdata[k][k2] = gen() & 0xffff; // initialise to random integer
       }
   }
   printf("%-40s\t", "memcpy");

--- a/benchmark/linux/linux-perf-events.h
+++ b/benchmark/linux/linux-perf-events.h
@@ -14,15 +14,15 @@
 #include <vector>
 
 template <int TYPE = PERF_TYPE_HARDWARE> class LinuxEvents {
-  int fd;
+  int group;
   bool working;
   perf_event_attr attribs;
   int num_events;
   std::vector<uint64_t> temp_result_vec;
-  std::vector<uint64_t> ids;
+  std::vector<int> fds;
 
 public:
-  explicit LinuxEvents(std::vector<int> config_vec) : fd(0), working(true) {
+  explicit LinuxEvents(std::vector<int> config_vec) : group(-1), working(true) {
     memset(&attribs, 0, sizeof(attribs));
     attribs.type = TYPE;
     attribs.size = sizeof(attribs);
@@ -36,16 +36,16 @@ public:
     const int cpu = -1; // all CPUs
     const unsigned long flags = 0;
 
-    int group = -1; // no group
     num_events = config_vec.size();
     uint32_t i = 0;
     for (auto config : config_vec) {
       attribs.config = config;
-      fd = syscall(__NR_perf_event_open, &attribs, pid, cpu, group, flags);
+      int fd = syscall(__NR_perf_event_open, &attribs, pid, cpu, group, flags);
       if (fd == -1) {
         report_error("perf_event_open");
       }
-      ioctl(fd, PERF_EVENT_IOC_ID, &ids[i++]);
+
+      fds.push_back(fd);
       if (group == -1) {
         group = fd;
       }
@@ -54,24 +54,28 @@ public:
     temp_result_vec.resize(num_events * 2 + 1);
   }
 
-  ~LinuxEvents() { close(fd); }
+  ~LinuxEvents() {
+    for (auto fd : fds) {
+      close(fd);
+    }
+  }
 
   inline void start() {
-    if (ioctl(fd, PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP) == -1) {
+    if (ioctl(group, PERF_EVENT_IOC_RESET, PERF_IOC_FLAG_GROUP) == -1) {
       report_error("ioctl(PERF_EVENT_IOC_RESET)");
     }
 
-    if (ioctl(fd, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP) == -1) {
+    if (ioctl(group, PERF_EVENT_IOC_ENABLE, PERF_IOC_FLAG_GROUP) == -1) {
       report_error("ioctl(PERF_EVENT_IOC_ENABLE)");
     }
   }
 
   inline void end(std::vector<unsigned long long> &results) {
-    if (ioctl(fd, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP) == -1) {
+    if (ioctl(group, PERF_EVENT_IOC_DISABLE, PERF_IOC_FLAG_GROUP) == -1) {
       report_error("ioctl(PERF_EVENT_IOC_DISABLE)");
     }
 
-    if (read(fd, &temp_result_vec[0], temp_result_vec.size() * 8) == -1) {
+    if (read(group, &temp_result_vec[0], temp_result_vec.size() * 8) == -1) {
       report_error("read");
     }
     // our actual results are in slots 1,3,5, ... of this structure


### PR DESCRIPTION
As promised, the other half of the change set.  I apologise for taking a bit longer with this one; things got in the way.

The basic idea of the improvement is to touch the subarray we want to benchmark before the benchmark.  This way, the subarray is in L1 cache if it fits, thus giving much more realistic performance characteristics for small values of `-n`.