### PR TITLE
Remove prefetch instructions, allow for suboptimal benchmark parameters

### DIFF
--- a/asm/countavx512_32.s
+++ b/asm/countavx512_32.s
@@ -113,22 +113,6 @@ countavx512:
         vpternlogd zmm2, zmm3, zmm4, 0x96
         vpternlogd zmm3, zmm7, zmm4, 0xE8
         add     rsi, 960
-        prefetcht0 [rsi+0xB40]
-        prefetcht0 [rsi+0xB80]
-        prefetcht0 [rsi+0xBC0]
-        prefetcht0 [rsi+0xC00]
-        prefetcht0 [rsi+0xC40]
-        prefetcht0 [rsi+0xC80]
-        prefetcht0 [rsi+0xCC0]
-        prefetcht0 [rsi+0xD00]
-        prefetcht0 [rsi+0xD40]
-        prefetcht0 [rsi+0xD80]
-        prefetcht0 [rsi+0xDC0]
-        prefetcht0 [rsi+0xE00]
-        prefetcht0 [rsi+0xE40]
-        prefetcht0 [rsi+0xE80]
-        prefetcht0 [rsi+0xEC0]
-        prefetcht0 [rsi+0xF00]
         vpsrld  zmm4, zmm0, 1
         vpaddd  zmm5, zmm1, zmm1
         vpsrld  zmm6, zmm2, 1

--- a/asm/countavx512_64.s
+++ b/asm/countavx512_64.s
@@ -113,22 +113,6 @@ countavx512:
         vpternlogd zmm2, zmm3, zmm4, 0x96
         vpternlogd zmm3, zmm7, zmm4, 0xE8
         add     rsi, 960
-        prefetcht0 [rsi+0xB40]
-        prefetcht0 [rsi+0xB80]
-        prefetcht0 [rsi+0xBC0]
-        prefetcht0 [rsi+0xC00]
-        prefetcht0 [rsi+0xC40]
-        prefetcht0 [rsi+0xC80]
-        prefetcht0 [rsi+0xCC0]
-        prefetcht0 [rsi+0xD00]
-        prefetcht0 [rsi+0xD40]
-        prefetcht0 [rsi+0xD80]
-        prefetcht0 [rsi+0xDC0]
-        prefetcht0 [rsi+0xE00]
-        prefetcht0 [rsi+0xE40]
-        prefetcht0 [rsi+0xE80]
-        prefetcht0 [rsi+0xEC0]
-        prefetcht0 [rsi+0xF00]
         vpsrld  zmm4, zmm0, 1
         vpaddd  zmm5, zmm1, zmm1
         vpsrld  zmm6, zmm2, 1

--- a/benchmark/linux/instrumented_benchmark.cpp
+++ b/benchmark/linux/instrumented_benchmark.cpp
@@ -36,7 +36,8 @@ enum {
   OPT_VERBOSE    = 1 << 0,
   OPT_TEST       = 1 << 1,
   OPT_COMPENSATE = 1 << 2,
-  OPT_TOUCH = 1 << 3,
+  OPT_TOUCH      = 1 << 3,
+  OPT_FORCE      = 1 << 4,
 };
 
 // Function pointer definition.
@@ -348,6 +349,7 @@ void  benchmarkCopy(C & vdata, BenchmarkState *overhead, uint32_t n, uint32_t m,
 static void print_usage(char *command) {
   printf(" Try %s -n 100000 -i 15 -v\n", command);
   printf("-c compensate overhead in measurements\n");
+  printf("-f force use of suboptimal benchmark parameters\n");
   printf("-m number of arrays\n");
   printf("-n number of 16-bit words per array\n");
   printf("-i number of iterations\n");
@@ -362,10 +364,13 @@ int main(int argc, char **argv) {
   int options = OPT_TEST;
   int c;
 
-  while ((c = getopt(argc, argv, "cvhm:n:i:t")) != -1) {
+  while ((c = getopt(argc, argv, "cfi:hm:n:tv")) != -1) {
     switch (c) {
     case 'c':
       options |= OPT_COMPENSATE;
+      break;
+    case 'f':
+      options |= OPT_FORCE;
       break;
     case 't':
       options |= OPT_TOUCH;
@@ -402,16 +407,18 @@ int main(int argc, char **argv) {
   }
 
   if (iterations == 0) {
-      iterations = 100;
+    iterations = 100;
   }
+
   size_t min_volume = 1000000;
-  if(m * n < min_volume) {
+  if(~options & OPT_FORCE && m * n < min_volume) {
     printf("The benchmark is designed to measure the time in units of m*n inputs.\n");
     printf("But your choices make m*n too small, so increasing m.\n");
     while(m * n < min_volume) {
        m++;
     }
   }
+
   printf("n = %zu m = %zu \n", n, m);
   printf("iterations = %zu \n", iterations);
   if (n == 0) {


### PR DESCRIPTION
In my attempts to produce consistent results, I noticed that the speed results for my algorithm had a rather large fluctuation.  Turns out the prefetch instructions do something weird to the cache when running with small sizes of `n`.  I have removed them for now.  The other kernels don't have them either and prefetching can be added to both algorithms if desired.

I've also added another option `-f` to allow strange parameter combinations to be used.  I hope to finish the benchmarks quickly.